### PR TITLE
feat: remove clearing of fallback folder

### DIFF
--- a/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.App.props
+++ b/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.App.props
@@ -29,10 +29,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreFallbackFolders>clear</RestoreFallbackFolders>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
   </PropertyGroup>

--- a/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.Library.props
+++ b/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.Library.props
@@ -28,10 +28,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreFallbackFolders>clear</RestoreFallbackFolders>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
   </PropertyGroup>

--- a/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.Test.props
+++ b/generic/Be.Vlaanderen.Basisregisters.Build.Pipeline.Settings.Test.props
@@ -30,10 +30,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreFallbackFolders>clear</RestoreFallbackFolders>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
   </PropertyGroup>


### PR DESCRIPTION
This was introduced in response to a jetbrains rider tooling bug on
linux. In current tooling versions, this line causes bugs. There seems
to be no clear purpose to this line anymore, so I'm removing it.